### PR TITLE
feat: add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "custom_components/bradford_white_connect/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate release version
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prefix="$(date -u +'%Y.%m.%d')"
+          latest_same_day_tag="$({ gh release list --limit 100 --json tagName --jq '.[] | .tagName' || true; } | grep -E "^${prefix}\\.[0-9]+$" | sort -V | tail -n1)"
+
+          if [ -n "$latest_same_day_tag" ]; then
+            n="${latest_same_day_tag##*.}"
+            n=$((n + 1))
+          else
+            n=1
+          fi
+
+          version="${prefix}.${n}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Using version: ${version}"
+
+      - name: Update manifest version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = Path('custom_components/bradford_white_connect/manifest.json')
+          data = json.loads(manifest.read_text())
+          data['version'] = os.environ['VERSION']
+          manifest.write_text(json.dumps(data, indent=2) + '\n')
+          PY
+
+      - name: Create release archive
+        run: |
+          cd custom_components
+          zip -r ../bradford_white_connect.zip bradford_white_connect
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
+          files: bradford_white_connect.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-on:
+"on":
   workflow_dispatch:
   push:
     branches:
@@ -8,15 +8,87 @@ on:
     paths:
       - "custom_components/bradford_white_connect/**"
 
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install pipenv
+        env:
+          PIPENV_VENV_IN_PROJECT: true
+        run: |
+          pip install pipenv
+          pipenv install
+      - name: Run Trunk Check
+        uses: trunk-io/trunk-action@v1
+
+  validate-hassfest:
+    name: Hassfest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Validate Hassfest
+        uses: home-assistant/actions/hassfest@master
+
+  validate-hacs:
+    name: HACS
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Validate HACS
+        uses: hacs/action@main
+        with:
+          category: integration
+          ignore: brands
+
+  test:
+    name: Pytest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install test dependencies
+        run: pip install pytest
+      - name: Run pytest
+        run: pytest -q
+
   release:
+    needs: [lint, validate-hassfest, validate-hacs, test]
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -25,19 +97,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          prefix="$(date -u +'%Y.%m.%d')"
-          latest_same_day_tag="$({ gh release list --limit 100 --json tagName --jq '.[] | .tagName' || true; } | grep -E "^${prefix}\\.[0-9]+$" | sort -V | tail -n1)"
+          set -euo pipefail
 
-          if [ -n "$latest_same_day_tag" ]; then
-            n="${latest_same_day_tag##*.}"
-            n=$((n + 1))
+          release_tags="$(gh release list --limit 100 --json tagName --jq '.[].tagName')"
+          latest_tag="$(printf '%s\n' "$release_tags" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)"
+
+          if [ -n "$latest_tag" ]; then
+            current_version="${latest_tag#v}"
+            patch="${current_version##*.}"
+            version="${current_version%.*}.$((patch + 1))"
           else
-            n=1
+            version="$(python3 -c 'import json; print(json.load(open("custom_components/bradford_white_connect/manifest.json"))["version"])')"
+            if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Manifest version is not a semantic version: $version" >&2
+              exit 1
+            fi
           fi
 
-          version="${prefix}.${n}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Using version: ${version}"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+          echo "Using version: v${version}"
 
       - name: Update manifest version
         env:
@@ -60,8 +139,9 @@ jobs:
           zip -r ../bradford_white_connect.zip bradford_white_connect
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ steps.version.outputs.version }}
-          name: ${{ steps.version.outputs.version }}
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
           files: bradford_white_connect.zip

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Click download and after this, restart Home Assistant.
 2. Clone this repository.
 3. Copy the `custom_components/bradford_white_connect` folder into your Home Assistant's `custom_components` folder.
 
+## Releases
+
+Changes to the integration merged into `main` are released automatically after lint, Hassfest, HACS, and pytest validation pass. Each release increments the semantic patch version (for example, `0.2.15` to `0.2.16`) and uses the corresponding `v0.2.16` Git tag. Maintainers can also run the **Release** workflow manually from the Actions tab.
+
 ## Configuring
 
 1. Add `Bradford White Connect` integration via UI. Using My Home Assistant service, you can click on:\


### PR DESCRIPTION
Adds an automated GitHub Actions release workflow for the Bradford White Connect Home Assistant integration.

What it does:

- Triggers on manual dispatch and integration changes pushed to `main`
- Runs lint, Hassfest, HACS, and pytest validation before publishing
- Increments the semantic patch version and creates the matching `vX.Y.Z` tag
- Updates `manifest.json` in the packaged integration
- Builds a HACS-compatible zip asset
- Creates a GitHub release with generated release notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated releases for validated changes merged into the main branch.
  * Added manual release workflow support.
  * Releases include downloadable integration packages with incremented patch versions.

* **Documentation**
  * Added README guidance explaining the automated release process and manual workflow option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
