### PR TITLE
Fix availability check and expose device telemetry / diagnostics

### DIFF
--- a/custom_components/bradford_white_connect/__init__.py
+++ b/custom_components/bradford_white_connect/__init__.py
@@ -17,7 +17,7 @@ from .coordinator import (
 )
 from .helper import get_device_property_value
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.WATER_HEATER]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.WATER_HEATER]
 
 
 @dataclass

--- a/custom_components/bradford_white_connect/binary_sensor.py
+++ b/custom_components/bradford_white_connect/binary_sensor.py
@@ -1,0 +1,103 @@
+"""Binary sensor platform for the Bradford White Connect integration."""
+
+from dataclasses import dataclass
+
+from bradford_white_connect_client.types import Device
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import BradfordWhiteConnectData
+from .const import DOMAIN
+from .coordinator import BradfordWhiteConnectStatusCoordinator
+from .entity import BradfordWhiteConnectStatusEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class BWBinarySensorDescription(BinarySensorEntityDescription):
+    """Describes a BW property exposed as a binary sensor."""
+
+    property_name: str
+
+
+PROPERTY_BINARY_SENSORS: tuple[BWBinarySensorDescription, ...] = (
+    BWBinarySensorDescription(
+        key="compressor_running",
+        property_name="comp_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+    ),
+    BWBinarySensorDescription(
+        key="evap_fan_running",
+        property_name="evap_fan_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BWBinarySensorDescription(
+        key="upper_element_running",
+        property_name="upper_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+    ),
+    BWBinarySensorDescription(
+        key="lower_element_running",
+        property_name="lower_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Bradford White Connect binary_sensor platform."""
+    data: BradfordWhiteConnectData = hass.data[DOMAIN][entry.entry_id]
+    entities = [
+        BradfordWhiteConnectPropertyBinarySensor(
+            data.status_coordinator, dsn, device, desc
+        )
+        for dsn, device in data.status_coordinator.data.items()
+        for desc in PROPERTY_BINARY_SENSORS
+        if desc.property_name in (device.properties or {})
+    ]
+    async_add_entities(entities)
+
+
+class BradfordWhiteConnectPropertyBinarySensor(
+    BradfordWhiteConnectStatusEntity, BinarySensorEntity
+):
+    """Binary sensor derived from a 0/1 device property."""
+
+    entity_description: BWBinarySensorDescription
+
+    def __init__(
+        self,
+        coordinator: BradfordWhiteConnectStatusCoordinator,
+        dsn: str,
+        device: Device,
+        description: BWBinarySensorDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator, dsn, device)
+        self.entity_description = description
+        self._attr_unique_id = f"{dsn}_{description.key}"
+        # has_entity_name=True is set on base class — HA prepends the device name.
+        self._attr_name = description.key.replace("_", " ").title()
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the property reports a non-zero/truthy value."""
+        prop = self.device.properties.get(self.entity_description.property_name)
+        if prop is None:
+            return None
+        val = getattr(prop, "value", None)
+        if val is None:
+            return None
+        try:
+            return int(val) == 1
+        except (TypeError, ValueError):
+            return bool(val)

--- a/custom_components/bradford_white_connect/entity.py
+++ b/custom_components/bradford_white_connect/entity.py
@@ -52,8 +52,17 @@ class BradfordWhiteConnectStatusEntity(
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return super().available and self.device.connection_status == "Online"
+        """Return True if entity is available.
+
+        Availability is governed by the coordinator's last-update success.
+        The previous strict `device.connection_status == "Online"` check was
+        removed because the cloud API can report `connection_status='Offline'`
+        for devices that are reachable — the BW Connect app shows the unit as
+        online and the coordinator successfully fetches device properties at
+        the regular interval. The field appears to track something other than
+        actual cloud reachability.
+        """
+        return super().available
 
 
 class BradfordWhiteConnectEnergyEntity(

--- a/custom_components/bradford_white_connect/sensor.py
+++ b/custom_components/bradford_white_connect/sensor.py
@@ -1,42 +1,223 @@
-"""The sensor platform for the A. O. Smith integration."""
+"""The sensor platform for the Bradford White Connect integration."""
+
+from dataclasses import dataclass
+from typing import Any, Callable
 
 from bradford_white_connect_client.types import Device
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfEnergy
+from homeassistant.const import (
+    EntityCategory,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import BradfordWhiteConnectData
 from .const import DOMAIN, ENERGY_TYPE_HEAT_PUMP, ENERGY_TYPE_RESISTANCE
-from .coordinator import BradfordWhiteConnectEnergyCoordinator
-from .entity import BradfordWhiteConnectEnergyEntity
+from .coordinator import BradfordWhiteConnectEnergyCoordinator, BradfordWhiteConnectStatusCoordinator
+from .entity import BradfordWhiteConnectEnergyEntity, BradfordWhiteConnectStatusEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class BWSensorDescription(SensorEntityDescription):
+    """Describes a BW property exposed as a sensor."""
+
+    property_name: str
+    value_fn: Callable[[Any], Any] | None = None
+
+
+PROPERTY_SENSORS: tuple[BWSensorDescription, ...] = (
+    # ----- TEMPERATURE -----
+    BWSensorDescription(
+        key="tank_temp_lower",
+        property_name="tank_temp_lower",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    BWSensorDescription(
+        key="ambient_temp",
+        property_name="appliance_ambient_out",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    BWSensorDescription(
+        key="evap_inlet_temp",
+        property_name="evap_inlet_temp",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+    ),
+    BWSensorDescription(
+        key="evap_outlet_temp",
+        property_name="evap_outlet_temp",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+    ),
+    BWSensorDescription(
+        key="comp_discharge_temp",
+        property_name="comp_discharge_temp",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+    ),
+    # ----- POWER -----
+    BWSensorDescription(
+        key="hp_power",
+        property_name="hp_power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    BWSensorDescription(
+        key="re_power",
+        property_name="re_power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    # ----- ELECTRICAL -----
+    BWSensorDescription(
+        key="mains_voltage",
+        property_name="mains_voltage",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
+    ),
+    BWSensorDescription(
+        key="mains_current",
+        property_name="mains_current",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=2,
+    ),
+    BWSensorDescription(
+        key="hp_current",
+        property_name="hp_current",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=2,
+    ),
+    # ----- DIAGNOSTIC TELEMETRY -----
+    BWSensorDescription(
+        key="wifi_signal_strength",
+        property_name="wifi_signal_strength",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BWSensorDescription(
+        key="filter_percentage",
+        property_name="filter_percentage",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BWSensorDescription(
+        key="appliance_hours",
+        property_name="appliance_hours",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BWSensorDescription(
+        key="comp_hours",
+        property_name="comp_hours",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # ----- HOT WATER CAPACITY -----
+    BWSensorDescription(
+        key="available_thermal_capacity",
+        property_name="available_thermal_capacity",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    BWSensorDescription(
+        key="stored_thermal_capacity",
+        property_name="stored_thermal_capacity",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    # ----- DAILY TOTAL ENERGY -----
+    BWSensorDescription(
+        key="daily_total_energy",
+        property_name="daily_total_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+    ),
+    # ----- DIAGNOSTIC TEXT -----
+    BWSensorDescription(
+        key="alarm",
+        property_name="alarm",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BWSensorDescription(
+        key="drm_status",
+        property_name="drm_status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up Bradford White Connect water heater platform."""
+    """Set up Bradford White Connect sensor platform."""
     data: BradfordWhiteConnectData = hass.data[DOMAIN][entry.entry_id]
 
-    # Add energy sensor entities for each device
-    async_add_entities(
+    energy_entities = [
         BradfordWhiteConnectEnergySensorEntity(
-            data.energy_coordinator, dsn, device, ENERGY_TYPE_RESISTANCE
+            data.energy_coordinator, dsn, device, energy_type
         )
         for dsn, device in data.status_coordinator.data.items()
-    )
+        for energy_type in (ENERGY_TYPE_RESISTANCE, ENERGY_TYPE_HEAT_PUMP)
+    ]
 
-    async_add_entities(
-        BradfordWhiteConnectEnergySensorEntity(
-            data.energy_coordinator, dsn, device, ENERGY_TYPE_HEAT_PUMP
-        )
+    property_entities = [
+        BradfordWhiteConnectPropertySensor(data.status_coordinator, dsn, device, desc)
         for dsn, device in data.status_coordinator.data.items()
-    )
+        for desc in PROPERTY_SENSORS
+        if desc.property_name in (device.properties or {})
+    ]
+
+    async_add_entities(energy_entities + property_entities)
 
 
 class BradfordWhiteConnectEnergySensorEntity(
@@ -60,7 +241,8 @@ class BradfordWhiteConnectEnergySensorEntity(
         """Initialize the entity."""
         super().__init__(coordinator, dsn, device)
         energy_type_title = " ".join(energy_type.split("_")).title()
-        self._attr_name = f"{device.properties['product_name'].value} {energy_type_title} Energy Usage"
+        # has_entity_name=True is on base class — let HA prepend device name.
+        self._attr_name = f"{energy_type_title} Energy Usage"
         self._attr_unique_id = f"{energy_type}_{dsn}"
         self._device = device
         self._dsn = dsn
@@ -70,3 +252,42 @@ class BradfordWhiteConnectEnergySensorEntity(
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         return self.energy_usage
+
+
+class BradfordWhiteConnectPropertySensor(
+    BradfordWhiteConnectStatusEntity, SensorEntity
+):
+    """Sensor for any device property exposed by the status coordinator."""
+
+    entity_description: BWSensorDescription
+
+    def __init__(
+        self,
+        coordinator: BradfordWhiteConnectStatusCoordinator,
+        dsn: str,
+        device: Device,
+        description: BWSensorDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator, dsn, device)
+        self.entity_description = description
+        self._attr_unique_id = f"{dsn}_{description.key}"
+        # has_entity_name=True is set on base class — HA will prepend the device
+        # name automatically, so just supply the suffix here.
+        self._attr_name = description.key.replace("_", " ").title()
+
+    @property
+    def native_value(self) -> Any:
+        """Return the current value of the property."""
+        prop = self.device.properties.get(self.entity_description.property_name)
+        if prop is None:
+            return None
+        val = getattr(prop, "value", None)
+        if val is None:
+            return None
+        if self.entity_description.value_fn:
+            try:
+                val = self.entity_description.value_fn(val)
+            except Exception:  # noqa: BLE001
+                return None
+        return val


### PR DESCRIPTION
 This PR contains two related but independent changes (split into two
  commits so you can cherry-pick if desired):

  ## 1. Fix: don't gate availability on `connection_status` field

  Removes the strict `device.connection_status == "Online"` check in
  `BradfordWhiteConnectStatusEntity.available`. The cloud API can return
  `connection_status='Offline'` for devices that are clearly reachable —
  the official BW Connect app shows the unit as online and the coordinator
  successfully fetches all device properties at the regular interval. This
  field appears to track something other than actual cloud reachability.

  The coordinator's update success state (inherited from
  `CoordinatorEntity.available`) is a more reliable indicator and is what
  governs availability after this change.

  **Repro:** any account where the cloud reports `connection_status='Offline'`
  for an online device. The `water_heater` entity stays unavailable forever
  even though the integration is healthy.

  ## 2. Feat: expose device telemetry, diagnostics, and component status

  Adds 22 new sensor entities and 4 new binary_sensor entities, all derived
  from device properties already fetched by the status coordinator on every
  poll. No new API calls, no extra cloud load.

  **New sensor entities** (created only if the property is present in
  `device.properties`, so model/firmware variants are handled):

  | Category | Properties |
  |---|---|
  | Temperature | `tank_temp_lower`, `appliance_ambient_out`, `evap_inlet_temp`,
  `evap_outlet_temp`, `comp_discharge_temp` |
  | Power | `hp_power`, `re_power` |
  | Electrical (diag) | `mains_voltage`, `mains_current`, `hp_current` |
  | Diag / health | `wifi_signal_strength`, `filter_percentage`, `appliance_hours`, `comp_hours`,
   `alarm`, `drm_status` |
  | Capacity | `available_thermal_capacity`, `stored_thermal_capacity`, `daily_total_energy` |

  **New binary_sensor entities** (`BinarySensorDeviceClass.RUNNING`):
  `comp_status`, `evap_fan_status`, `upper_status`, `lower_status`

  Implementation notes:
  - Adds `Platform.BINARY_SENSOR` to `PLATFORMS` in `__init__.py`.
  - Uses `EntityDescription` pattern with a `property_name` field — easy to
    add more later. New entities only created if `description.property_name in
  device.properties`.
  - Existing energy sensors no longer redundantly include the device name in
    `_attr_name`; they now rely on the `_attr_has_entity_name = True` pattern
    the rest of the integration uses, so HA prepends the device name once.

  Tested on a 50-gal hybrid HPWH (model RE2H50S10-1NCTT-CON, firmware 6.0.6.0)
  running in a US household. All 26 entities populate correctly and update on
  the regular 5-min coordinator interval.
