### PR TITLE
Fix API connection with client 0.0.23

### DIFF
--- a/custom_components/bradford_white_connect/manifest.json
+++ b/custom_components/bradford_white_connect/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ablyler/home-assistant-bradford-white-connect/issues",
   "requirements": ["bradford-white-connect-client==0.0.23"],
-  "version": "0.2.12"
+  "version": "0.2.13"
 }

--- a/custom_components/bradford_white_connect/manifest.json
+++ b/custom_components/bradford_white_connect/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/ablyler/home-assistant-bradford-white-connect",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ablyler/home-assistant-bradford-white-connect/issues",
-  "requirements": ["bradford-white-connect-client==0.0.21"],
+  "requirements": ["bradford-white-connect-client==0.0.23"],
   "version": "0.2.12"
 }


### PR DESCRIPTION
## Summary

- update the integration runtime dependency to `bradford-white-connect-client==0.0.23`
- use the client release that accepts the backend's new `oem` device field

## Root cause

The Bradford White API began returning an `oem` field. The previously pinned client version rejected it while constructing `Device`, causing integration setup to fail.

Fixes #69.

## Validation

- installed `bradford-white-connect-client==0.0.23`
- verified `Device` accepts the `oem` constructor parameter
- validated `manifest.json` and checked the diff for whitespace errors