### PR TITLE
Upgrade Trunk toolchain and restore release CI

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,34 +2,37 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.12
+  version: 1.25.0
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.8
+      ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
-    - node@18.20.5
-    - python@3.10.8
+    - node@22.16.0
+    - python@3.14.4
 lint:
   enabled:
-    - mypy@1.15.0
-    - checkov@3.2.408
-    - trivy@0.61.1
-    - hadolint@2.12.1-beta
-    - markdownlint@0.44.0
-    - actionlint@1.7.7
-    - bandit@1.8.3
-    - black@25.1.0
-    - flake8@7.2.0
+    - grype@0.116.0
+    - osv-scanner@2.4.0
+    - pinact@4.1.0
+    - mypy@2.3.0
+    - checkov@3.3.8
+    - trivy@0.72.0
+    - hadolint@2.14.0
+    - markdownlint@0.49.1
+    - actionlint@1.7.12
+    - bandit@1.9.4
+    - black@26.5.1
+    - flake8@7.3.0
     - git-diff-check
-    - isort@6.0.1
-    - prettier@3.5.3
-    - ruff@0.11.7
-    - taplo@0.9.3
-    - trufflehog@3.88.25
-    - yamllint@1.37.0
+    - isort@8.0.1
+    - prettier@3.9.5
+    - ruff@0.15.22
+    - taplo@0.10.0
+    - trufflehog@3.95.9
+    - yamllint@1.38.0
   ignore:
     - linters: [ALL]
       paths:

--- a/custom_components/bradford_white_connect/manifest.json
+++ b/custom_components/bradford_white_connect/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ablyler/home-assistant-bradford-white-connect/issues",
   "requirements": ["bradford-white-connect-client==0.0.23"],
-  "version": "0.2.13"
+  "version": "0.2.14"
 }


### PR DESCRIPTION
## Summary

- upgrade the Trunk CLI and plugin bundle
- upgrade all configured runtimes and linters
- replace the broken `trivy@0.61.1` pin with `trivy@0.72.0`
- enable the additional security checks recommended by the current Trunk plugin bundle

## Root cause

The `v0.2.13` tag workflow failed because Trunk attempted to download a release asset for `trivy@0.61.1` that returned HTTP 404. Since the release job depends on lint, the automated GitHub release and moving version tags were skipped.

## Validation

- verified the Trivy 0.72.0 Linux release asset is available
- ran `trunk upgrade --yes-to-all`
- ran `trunk check --all --no-progress` successfully
- ran `git diff --check`